### PR TITLE
Add support for local tarballs

### DIFF
--- a/app/Foliage/CmdBuild.hs
+++ b/app/Foliage/CmdBuild.hs
@@ -101,8 +101,10 @@ cmdBuild
           IO.createDirectoryIfMissing True srcDir
 
         case packageSource of
-          TarballSource url mSubdir -> do
-            tarballPath <- remoteAssetNeed url
+          TarballSource location mSubdir -> do
+            tarballPath <- case location of
+                             RemoteTarball url -> remoteAssetNeed url
+                             LocalTarball path -> need [path] >> return path
 
             withTempDir $ \tmpDir -> do
               cmd_ ["tar", "xzf", tarballPath, "-C", tmpDir]

--- a/app/Foliage/CmdImportHackage.hs
+++ b/app/Foliage/CmdImportHackage.hs
@@ -53,7 +53,7 @@ importIndex f (Tar.Next e es) m =
                 pure $
                   Just $
                     PackageMeta
-                      { packageSource = TarballSource (pkgIdToHackageUrl pkgId) Nothing,
+                      { packageSource = TarballSource (RemoteTarball $ pkgIdToHackageUrl pkgId) Nothing,
                         packageTimestamp = Just time,
                         packageRevisions = [],
                         packageForceVersion = False


### PR DESCRIPTION
I found this useful in https://gitlab.haskell.org/ghc/head.hackage/-/merge_requests/228.

In short, a tarball source may either be a remote tarball (specified using the `url` attribute) or a local tarball (specified using `path`).