### PR TITLE
Do not auto-generate keys

### DIFF
--- a/app/Foliage/CmdBuild.hs
+++ b/app/Foliage/CmdBuild.hs
@@ -74,8 +74,11 @@ buildAction
       SignOptsSignWithKeys keysPath -> do
         ks <- doesDirectoryExist keysPath
         unless ks $ do
-          putWarn $ "You don't seem to have created a set of TUF keys. I will create one in " <> keysPath
-          liftIO $ createKeys keysPath
+          putError $ unwords
+            [ "I cannot find a set of TUF keys in " <> keysPath <> ","
+            , "Use the create-keys command to create them."
+            ]
+          fail "Keys not found"
         return $ \name -> readKeysAt (keysPath </> name)
       SignOptsDon'tSign ->
         return $ const $ pure []


### PR DESCRIPTION
This makes not signing the repo the default. If the user passes `--sign-with-keys KEYS` and the path `KEYS` does not exist, foliage tells the user to create a set of keys.