### PR TITLE
Build in parallel

### DIFF
--- a/app/Foliage/Options.hs
+++ b/app/Foliage/Options.hs
@@ -51,7 +51,8 @@ data BuildOptions = BuildOptions
     buildOptsCurrentTime :: Maybe UTCTime,
     buildOptsExpireSignaturesOn :: Maybe UTCTime,
     buildOptsInputDir :: FilePath,
-    buildOptsOutputDir :: FilePath
+    buildOptsOutputDir :: FilePath,
+    buildOptsNumThreads :: Int
   }
 
 buildCommand :: Parser Command
@@ -89,6 +90,15 @@ buildCommand =
                   <> help "Repository output directory"
                   <> showDefault
                   <> value "_repo"
+              )
+            <*> option
+              auto
+              ( long "num-jobs"
+                  <> short 'j'
+                  <> metavar "JOBS"
+                  <> help "Number of jobs to run in parallel, 0 is 'all available cores'"
+                  <> showDefault
+                  <> value 1
               )
         )
   where

--- a/foliage.cabal
+++ b/foliage.cabal
@@ -41,6 +41,7 @@ executable foliage
         ImportQualifiedPost LambdaCase NamedFieldPuns ViewPatterns
 
     ghc-options:        -Wall
+    ghc-options:        -threaded
     build-depends:
         base                 >=4.14.3.0   && <4.18,
         aeson                >=2.0.3.0    && <2.2,


### PR DESCRIPTION
This cuts the time to build `cardano-haskell-packages` down to 30s from >2mins.
