### PR TITLE
Implement metadata output

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,5 +25,3 @@ jobs:
            authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - run: nix build --accept-flake-config
-
-      - run: nix flake check --accept-flake-config --allow-import-from-derivation

--- a/app/Foliage/Options.hs
+++ b/app/Foliage/Options.hs
@@ -52,7 +52,8 @@ data BuildOptions = BuildOptions
     buildOptsExpireSignaturesOn :: Maybe UTCTime,
     buildOptsInputDir :: FilePath,
     buildOptsOutputDir :: FilePath,
-    buildOptsNumThreads :: Int
+    buildOptsNumThreads :: Int,
+    buildOptsWriteMetadata :: Bool
   }
 
 buildCommand :: Parser Command
@@ -99,6 +100,11 @@ buildCommand =
                   <> help "Number of jobs to run in parallel, 0 is 'all available cores'"
                   <> showDefault
                   <> value 1
+              )
+            <*> switch
+              ( long "write-metadata"
+                  <> help "Write metadata in the output-directory"
+                  <> showDefault
               )
         )
   where

--- a/app/Foliage/Pages.hs
+++ b/app/Foliage/Pages.hs
@@ -58,8 +58,8 @@ data AllPackagesPageEntry = AllPackagesPageEntry
 makeAllPackagesPage :: UTCTime -> FilePath -> [PackageVersionMeta] -> Action ()
 makeAllPackagesPage currentTime outputDir packageVersions = do
   let packages =
-        sortOn allPackagesPageEntryPkgId $
-          map
+        sortOn allPackagesPageEntryPkgId
+          $ map
             ( ( \PackageVersionMeta {pkgId, pkgSpec = PackageVersionSpec {packageVersionTimestamp, packageVersionRevisions, packageVersionSource}} ->
                   AllPackagesPageEntry
                     { allPackagesPageEntryPkgId = pkgId,
@@ -72,7 +72,7 @@ makeAllPackagesPage currentTime outputDir packageVersions = do
                 . head
                 . sortOn (Down . pkgVersion . pkgId)
             )
-            $ groupBy ((==) `on` (pkgName . pkgId)) packageVersions
+          $ groupBy ((==) `on` (pkgName . pkgId)) packageVersions
   traced "webpages / all-packages" $ do
     IO.createDirectoryIfMissing True (outputDir </> "all-packages")
     TL.writeFile (outputDir </> "all-packages" </> "index.html") $
@@ -105,16 +105,16 @@ makeAllPackageVersionsPage currentTime outputDir packageVersions = do
                     allPackageVersionsPageEntryTimestamp = fromMaybe currentTime packageVersionTimestamp,
                     allPackageVersionsPageEntryTimestampPosix = utcTimeToPOSIXSeconds (fromMaybe currentTime packageVersionTimestamp),
                     allPackageVersionsPageEntrySource = packageVersionSource
-                  } :
-                map
-                  ( \RevisionSpec {revisionTimestamp} ->
-                      AllPackageVersionsPageEntryRevision
-                        { allPackageVersionsPageEntryPkgId = pkgId,
-                          allPackageVersionsPageEntryTimestamp = revisionTimestamp,
-                          allPackageVersionsPageEntryTimestampPosix = utcTimeToPOSIXSeconds revisionTimestamp
-                        }
-                  )
-                  packageVersionRevisions
+                  }
+                  : map
+                    ( \RevisionSpec {revisionTimestamp} ->
+                        AllPackageVersionsPageEntryRevision
+                          { allPackageVersionsPageEntryPkgId = pkgId,
+                            allPackageVersionsPageEntryTimestamp = revisionTimestamp,
+                            allPackageVersionsPageEntryTimestampPosix = utcTimeToPOSIXSeconds revisionTimestamp
+                          }
+                    )
+                    packageVersionRevisions
             )
             packageVersions
 

--- a/app/Foliage/PrepareSource.hs
+++ b/app/Foliage/PrepareSource.hs
@@ -8,7 +8,6 @@ module Foliage.PrepareSource where
 import Control.Monad (when)
 import Data.ByteString qualified as BS
 import Data.Foldable (for_)
-import Data.Text qualified as T
 import Development.Shake
 import Development.Shake.Classes
 import Development.Shake.Rule
@@ -18,8 +17,8 @@ import Distribution.Types.PackageName (unPackageName)
 import Foliage.Meta
 import Foliage.RemoteAsset (fetchRemoteAsset)
 import Foliage.UpdateCabalFile (rewritePackageVersion)
+import Foliage.Utils.GitHub (githubRepoUrl)
 import GHC.Generics
-import Network.URI (URI (..), URIAuth (..), nullURI, nullURIAuth)
 import System.Directory qualified as IO
 import System.FilePath ((<.>), (</>))
 
@@ -79,12 +78,7 @@ addPrepareSourceRule inputDir cacheDir = addBuiltinRule noLint noIdentity run
             -- metadata.
             --
             GitHubSource repo rev mSubdir -> do
-              let url =
-                    nullURI
-                      { uriScheme = "https:",
-                        uriAuthority = Just nullURIAuth {uriRegName = "github.com"},
-                        uriPath = "/" </> T.unpack (unGitHubRepo repo) </> "tarball" </> T.unpack (unGitHubRev rev)
-                      }
+              let url = githubRepoUrl repo rev
 
               tarballPath <- fetchRemoteAsset url
 

--- a/app/Foliage/PrepareSource.hs
+++ b/app/Foliage/PrepareSource.hs
@@ -17,7 +17,7 @@ import Distribution.Types.PackageName (unPackageName)
 import Foliage.Meta
 import Foliage.RemoteAsset (fetchRemoteAsset)
 import Foliage.UpdateCabalFile (rewritePackageVersion)
-import Foliage.Utils.GitHub (githubRepoUrl)
+import Foliage.Utils.GitHub (githubRepoTarballUrl)
 import GHC.Generics
 import System.Directory qualified as IO
 import System.FilePath ((<.>), (</>))
@@ -78,7 +78,7 @@ addPrepareSourceRule inputDir cacheDir = addBuiltinRule noLint noIdentity run
             -- metadata.
             --
             GitHubSource repo rev mSubdir -> do
-              let url = githubRepoUrl repo rev
+              let url = githubRepoTarballUrl repo rev
 
               tarballPath <- fetchRemoteAsset url
 

--- a/app/Foliage/Utils/GitHub.hs
+++ b/app/Foliage/Utils/GitHub.hs
@@ -1,14 +1,25 @@
-module Foliage.Utils.GitHub where
+module Foliage.Utils.GitHub
+  ( githubRepoTarballUrl,
+    githubRepoUrl,
+  )
+where
 
 import Data.Text qualified as T
 import Foliage.Meta (GitHubRepo (unGitHubRepo), GitHubRev (unGitHubRev))
 import Network.URI (URI (..), URIAuth (..), nullURI, nullURIAuth)
 import System.FilePath ((</>))
 
-githubRepoUrl :: GitHubRepo -> GitHubRev -> URI
-githubRepoUrl repo rev =
+githubRepoTarballUrl :: GitHubRepo -> GitHubRev -> URI
+githubRepoTarballUrl repo rev =
   nullURI
     { uriScheme = "https:",
       uriAuthority = Just nullURIAuth {uriRegName = "github.com"},
       uriPath = "/" </> T.unpack (unGitHubRepo repo) </> "tarball" </> T.unpack (unGitHubRev rev)
+    }
+
+githubRepoUrl :: GitHubRepo -> GitHubRev -> URI
+githubRepoUrl repo rev =
+  nullURI
+    { uriScheme = "github:",
+      uriPath = T.unpack (unGitHubRepo repo) </> T.unpack (unGitHubRev rev)
     }

--- a/app/Foliage/Utils/GitHub.hs
+++ b/app/Foliage/Utils/GitHub.hs
@@ -1,6 +1,5 @@
 module Foliage.Utils.GitHub
   ( githubRepoTarballUrl,
-    githubRepoUrl,
   )
 where
 
@@ -15,11 +14,4 @@ githubRepoTarballUrl repo rev =
     { uriScheme = "https:",
       uriAuthority = Just nullURIAuth {uriRegName = "github.com"},
       uriPath = "/" </> T.unpack (unGitHubRepo repo) </> "tarball" </> T.unpack (unGitHubRev rev)
-    }
-
-githubRepoUrl :: GitHubRepo -> GitHubRev -> URI
-githubRepoUrl repo rev =
-  nullURI
-    { uriScheme = "github:",
-      uriPath = T.unpack (unGitHubRepo repo) </> T.unpack (unGitHubRev rev)
     }

--- a/app/Foliage/Utils/GitHub.hs
+++ b/app/Foliage/Utils/GitHub.hs
@@ -1,0 +1,14 @@
+module Foliage.Utils.GitHub where
+
+import Data.Text qualified as T
+import Foliage.Meta (GitHubRepo (unGitHubRepo), GitHubRev (unGitHubRev))
+import Network.URI (URI (..), URIAuth (..), nullURI, nullURIAuth)
+import System.FilePath ((</>))
+
+githubRepoUrl :: GitHubRepo -> GitHubRev -> URI
+githubRepoUrl repo rev =
+  nullURI
+    { uriScheme = "https:",
+      uriAuthority = Just nullURIAuth {uriRegName = "github.com"},
+      uriPath = "/" </> T.unpack (unGitHubRepo repo) </> "tarball" </> T.unpack (unGitHubRev rev)
+    }

--- a/foliage.cabal
+++ b/foliage.cabal
@@ -34,6 +34,7 @@ executable foliage
         Foliage.Time
         Foliage.UpdateCabalFile
         Foliage.Utils.Aeson
+        Foliage.Utils.GitHub
         Network.URI.Orphans
 
     default-language:   Haskell2010


### PR DESCRIPTION
Implement a new flag "--write-metadata" which will create, in the output directory, a file `foliage/packages.json` with metadata about the package provenance.
    
The file `packages.json` file looks like this
    
    {
      "Win32-network-0.1.0.0": {
        "source": {
          "url": "github:input-output-hk/Win32-network/3825d3abf75f83f406c1f7161883c438dac7277d"
        },
        "timestamp": "2022-10-17T00:00:00Z"
      },
      "Win32-network-0.1.1.0": {
        ...

    
The idea is that tools fetching the repo can also fetch this file to obtain information about the package provenance.

E.g. in nix one could do

```
{
  inputs.CHaP = {
    url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
    flake = false;
  };

  outputs = { self, CHaP }:
    let chapPackages = builtins.fromJSON (builtins.readFile "${CHaP}/foliage/packages.json");
    in ...
}
```
