### PR TITLE
Rework flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,6 @@
         flake = project.flake (
           lib.attrsets.optionalAttrs (system == "x86_64-linux")
             { crossPlatforms = p: [ p.musl64 ]; }
-          // lib.attrsets.optionalAttrs (system == "aarch64-linux")
-            { crossPlatforms = p: [ p.aarch64-multiplatform-musl ]; }
         );
       in
 
@@ -55,8 +53,7 @@
         packages = { default = flake.packages."foliage:exe:foliage"; }
         // lib.attrsets.optionalAttrs (system == "x86_64-linux")
           { static = flake.packages."x86_64-unknown-linux-musl:foliage:exe:foliage"; }
-        // lib.attrsets.optionalAttrs (system == "aarch64-linux")
-          { static = flake.packages."aarch64-multiplatform-musl:foliage:exe:foliage"; };
+        ;
       }
     );
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
   outputs = { self, nixpkgs, flake-utils, haskell-nix, ... }:
 
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;


### PR DESCRIPTION
This reverts commit ae45f208a2b13e554150408a00662918261172c9 and fixes #53

Edit: 
- Rework the flake outputs. Leave a natively built default package, rename statically built output to foliage-static.
- Add tools to the project shell.