### PR TITLE
Add latest version page for packages

### DIFF
--- a/app/Foliage/CmdBuild.hs
+++ b/app/Foliage/CmdBuild.hs
@@ -12,9 +12,11 @@ import Data.Aeson qualified as Aeson
 import Data.Bifunctor (second)
 import Data.ByteString.Char8 qualified as BS
 import Data.ByteString.Lazy.Char8 qualified as BL
-import Data.List (sortOn)
+import Data.Function (on)
+import Data.List (sortOn, groupBy, sortBy)
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe, listToMaybe)
+import Data.Ord (comparing, Down(..))
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Traversable (for)
 import Development.Shake
@@ -102,7 +104,14 @@ buildAction
 
     makeAllPackageVersionsPage currentTime outputDir packageVersions
 
-    void $ forP packageVersions $ makePackageVersionPage outputDir
+    void $ forP packageVersions $ makePackageVersionPage prettyShow outputDir
+
+    let latestPackageVersions
+          = mapMaybe listToMaybe
+          . groupBy (on (==) $ pkgName . pkgId)
+          . sortBy (comparing (pkgName . pkgId) <> comparing (Down . pkgVersion . pkgId))
+          $ packageVersions
+    void $ forP latestPackageVersions $ makePackageVersionPage (prettyShow . packageName) outputDir
 
     when doWritePackageMeta $
       makeMetadataFile outputDir packageVersions

--- a/app/Foliage/Pages.hs
+++ b/app/Foliage/Pages.hs
@@ -26,7 +26,6 @@ import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
 import Development.Shake (Action, traced)
 import Distribution.Aeson (jsonGenericPackageDescription)
 import Distribution.Package (PackageIdentifier (pkgName, pkgVersion))
-import Distribution.Pretty (prettyShow)
 import Foliage.Meta (PackageVersionSource, RevisionSpec (..))
 import Foliage.Meta.Aeson ()
 import Foliage.PreparePackageVersion (PreparedPackageVersion (..))
@@ -142,11 +141,12 @@ makeAllPackageVersionsPage currentTime outputDir packageVersions =
       -- sort them by timestamp
       & sortOn (Down . allPackageVersionsPageEntryTimestamp)
 
-makePackageVersionPage :: FilePath -> PreparedPackageVersion -> Action ()
-makePackageVersionPage outputDir PreparedPackageVersion{pkgId, pkgTimestamp, pkgVersionSource, pkgDesc, cabalFileRevisions, pkgVersionIsDeprecated} = do
-  traced ("webpages / package / " ++ prettyShow pkgId) $ do
-    IO.createDirectoryIfMissing True (outputDir </> "package" </> prettyShow pkgId)
-    TL.writeFile (outputDir </> "package" </> prettyShow pkgId </> "index.html") $
+makePackageVersionPage :: (PackageIdentifier -> FilePath) -> FilePath -> PreparedPackageVersion -> Action ()
+makePackageVersionPage mkPageName outputDir PreparedPackageVersion{pkgId, pkgTimestamp, pkgVersionSource, pkgDesc, cabalFileRevisions, pkgVersionIsDeprecated} = do
+  let page = mkPageName pkgId
+  traced ("webpages / package / " ++ page) $ do
+    IO.createDirectoryIfMissing True (outputDir </> "package" </> page)
+    TL.writeFile (outputDir </> "package" </> page </> "index.html") $
       renderMustache packageVersionPageTemplate $
         object
           [ "pkgVersionSource" .= pkgVersionSource

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -39,6 +39,11 @@ main = do
             built <- BL.readFile "_repo/package/pkg-a-2.3.4.5/pkg-a.cabal"
             built @?= revised
 
+            step "Running latest package checks"
+            specificHtml <- BL.readFile "_repo/package/pkg-a-2.3.4.5/index.html"
+            latestHtml <- BL.readFile "_repo/package/pkg-a/index.html"
+            latestHtml @?= specificHtml
+
             step "Running tarball checks"
             withTarball "_repo/01-index.tar" $ \TarballAccessFn{lookupEntry} -> do
               lookupEntry "pkg-a/2.3.4.5/pkg-a.cabal" >>= \case


### PR DESCRIPTION
This PR adds a `package/package-name/index.html` page for the latest version of every package. Closes #98.